### PR TITLE
added comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,9 @@
     .imgitem img {
       width: 100%;
     }
+    .comment {
+      word-wrap: break-word;
+    }
   </style>
 </head>
 

--- a/index.html
+++ b/index.html
@@ -14,11 +14,13 @@
     .demo {
       margin: 40px;
     }
-    .imgitem {
-      border: 1px black solid;
+    .imgitemcontainer {
       width: 23%;
       margin: 0 20px 20px 0;
       display: inline-block;
+    }
+    .imgitem {
+      border: 1px black solid;
     }
     .imgitem img {
       width: 100%;
@@ -33,7 +35,6 @@
   <p>
     <input type="button" value="啟動GPS更新" onClick="startGPS();">
     <input type="button" value="停止GPS更新" onClick="stopGPS();">
-    <input type="button" value="截圖" onClick="screenshot();">
   </p>
   <p>當啟動GPS更新,不用聯網也可持續更新!!!
     <br> 只要網頁開著!
@@ -43,11 +44,15 @@
   <p><img id="map" />
   </p>
   <canvas id="myCanvas" width="500" height="500"></canvas>
+  <p>
+    <input id="commentText" type="text">
+    <input type="button" value="儲存截圖" onClick="screenshot();">
+    <p id="screenshotButtonMsg"></p>
+  </p>
 
   <div class="savedImages">
     Files:
     <div id="savedImages">
-
     </div>
   </div>
 

--- a/screenshot.js
+++ b/screenshot.js
@@ -1,3 +1,5 @@
+let MAX_COMMENT_LENGTH = 32;
+
 function pathJoin(parts, sep){
    var separator = sep || '/';
    var replace = new RegExp(separator+'{1,}', 'g');
@@ -17,32 +19,57 @@ function init() {
     });
 }
 
-function screenshot() {
-    var canvas  = document.getElementById("myCanvas");
+function screenshot() {    
+    var canvas = document.getElementById("myCanvas");
     var dataURL = canvas.toDataURL();
-    console.log("URL: " + dataURL);
+    var textBox = document.getElementById("commentText");
+    
+    let comment = (textBox.value === "") ? "無主旨" : textBox.value;
+    console.log(comment.length)
+    let msg = document.getElementById("screenshotButtonMsg");
+    if (comment.length > MAX_COMMENT_LENGTH) {
+        msg.innerHTML = "儲存失敗；註釋至多能有" + MAX_COMMENT_LENGTH + "個文字";
+        return;
+    } else if (comment.indexOf('.') != -1 || comment.indexOf('/') != -1) {
+        msg.innerHTML = "儲存失敗；註釋不可包含句號或斜線";
+        return;
+    } else {
+        msg.innerHTML = "";
+    }
 
     $.ajax({
       type: "POST",
       url: "screenshot/upload.php",
       data: { 
-         imgBase64: dataURL
+         imgBase64: dataURL,
+         comment: comment
       }
     }).done(function(o) {
-        let path = pathJoin(['screenshot', o.trim()]);
+      let path = pathJoin(['screenshot', o.trim()]);
       addImg(path);
     });
 }
 
 function addImg(path) {
-    var div = $('<div class="imgitem"></div>');
+    let commentStart = path.indexOf('-') + 1;
+    let commentEnd = path.lastIndexOf('.');
+    let comment = path.substr(commentStart, commentEnd - commentStart);
+    
+    var div = $('<div class="imgitemcontainer"></div>');
+    
+    var imgDiv = $('<div class="imgitem"></div>');
     var img = $('<img src="'+path+'">');
     var full_path = path.replace('thumbnail', 'img');
     var a = $('<a href="'+full_path+'" target="_blank"></a>');
-    $(a).append(img);
+    
+    var commentDiv = $('<div class="comment"></div>');
+    $(commentDiv).append(comment)
+    
+    $(imgDiv).append(img)
+    $(a).append(imgDiv);
     $(div).append(a);
+    $(div).append(commentDiv);
     $('#savedImages').prepend(div);
-    console.log()
 }
 
 init();

--- a/screenshot/upload.php
+++ b/screenshot/upload.php
@@ -2,13 +2,14 @@
     include 'thumbnail.php';
     define('UPLOAD_DIR', './uploads/img/');
     define('THUMBNAIL_UPLOAD_DIR', './uploads/thumbnail/');
+    $comment = $_POST['comment'];
     $img = $_POST['imgBase64'];
     $img = str_replace('data:image/png;base64,', '', $img);
     $img = str_replace(' ', '+', $img);
     $data = base64_decode($img);
     $id = uniqid();
-    $file = UPLOAD_DIR . $id . '.png';
+    $file = UPLOAD_DIR . $id . '-' . $comment . '.png';
     $success = file_put_contents($file, $data);
-    thumbnail($file, THUMBNAIL_UPLOAD_DIR.$id.'.png', 250);
-    print $success ? THUMBNAIL_UPLOAD_DIR.$id.'.png' : 'Unable to save the file.';
+    thumbnail($file, THUMBNAIL_UPLOAD_DIR.$id.'-'.$comment.'.png', 250);
+    print $success ? THUMBNAIL_UPLOAD_DIR.$id.'-'.$comment.'.png' : 'Unable to save the file.';
 ?> 


### PR DESCRIPTION
Adds comments under the image previews that can be input when saving a screenshot. Disallows `.` and `/` characters to prevent path traversal attacks at a basic level — but note that in real world applications this isn't a good enough defense. Comments are also limited to 32 characters.